### PR TITLE
Add a require for png_quantizator

### DIFF
--- a/lib/piet.rb
+++ b/lib/piet.rb
@@ -1,3 +1,4 @@
+require 'png_quantizator'
 require 'piet/carrierwave_extension'
 
 module Piet


### PR DESCRIPTION
I noticed that the gem was missing a require for png_quantizator, which didn't really come up unless you used the pngquant functions. This takes care of that.
