### PR TITLE
Simplify Carrierwave calls to remove `manipulate!` wrapper

### DIFF
--- a/lib/piet/carrierwave_extension.rb
+++ b/lib/piet/carrierwave_extension.rb
@@ -1,17 +1,11 @@
 module Piet
   module CarrierWaveExtension
-    def optimize(opts={})
-      manipulate! do |img|
-        Piet.optimize(current_path, opts)
-        img
-      end
+    def optimize(opts = {})
+      ::Piet.optimize(current_path, opts)
     end
 
     def pngquant
-      manipulate! do |img|
-        Piet.pngquant(current_path)
-        img
-      end
+      ::Piet.pngquant(current_path)
     end
   end
 end


### PR DESCRIPTION
A few times now, I've run across some strange behavior with regards to how Carrierwave images were being reprocessed - specifically, while optipng and/or pngquant were getting called, the optimized images weren't getting saved properly and reuploaded when using S3. The oddness seemed to be related to the call to `manipulate!` and the file moving that happens around that. I dug into some of the Carrierwave documentation and a few other examples of custom processors, and it seems like for the use case in Piet `manipulate!` is not required - we're not doing any image manipulation via rmagick/minimagick.

Anyway, I've been running a patched version of Piet with these changes in production for a while now, and everything seems to be working great. Figured I'd commit them upstream as well.
