### PR TITLE
Users should be able to tune the optipng optimization level from 0-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ The options are:
 
 * **verbose**: Whether you want to get the output of the command or not. It is interpreted as a Boolean value. Default: false.
 
-* **quality**: If you wanna add a compression, adjust the quality parameter. Valid values are any integer between 0 and 100 (100 means no compression and highest quality). Default: 100
+* **quality**: Adjust the output compression for JPEGs. Valid values are any integer between 0 and 100 (100 means no compression and highest quality). Default: 100
 
+* **level**: Adjust the optimization level for PNGs. Valid values are any integer between 0 and 7 (7 means highest compression and longest processing time). Default: 7
 
 CarrierWave integration
 -----------------------
@@ -133,7 +134,7 @@ would optimize those PNG, GIF and JPEG files but ouput nothing.
 Piet.optimize('/my/wonderful/pics/piggy.png', :verbose => true)
 ```
 
-would optimize that PNG/GIF file and ouput something similar to this one:
+would optimize that PNG/GIF file and output something similar to this one:
 
     ** Processing: piggy.png
     340x340 pixels, 4x8 bits/pixel, RGB+alpha

--- a/lib/piet.rb
+++ b/lib/piet.rb
@@ -29,9 +29,10 @@ module Piet
     end
 
     def optimize_png(path, opts)
+      level = (0..7).include?(opts[:level]) ? opts[:level] : 7
       vo = opts[:verbose] ? "-v" : "-quiet"
       path.gsub!(/([\(\)\[\]\{\}\*\?\\])/, '\\\\\1')
-      `#{command_path("optipng")} -o7 #{opts[:command_options]} #{vo} #{path}`
+      `#{command_path("optipng")} -o#{level} #{opts[:command_options]} #{vo} #{path}`
     end
 
     def optimize_jpg(path, opts)


### PR DESCRIPTION
While I'm sure there are multiple reasons you might want to use an optimization level other than the default of 7, I've found the greatest need for this when running integration tests. They can be painful slow when running heavy optimization with Piet.

This change makes it possible to specify a `level` option to the `optimize_png` call that you can use to adjust the default optimization level. The current default behavior (highest optimization level all the time) is preserved.
