### PR TITLE
Add mozjpeg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ Please note **you have to install the binary** in order to use the tool. Simply 
 
 Thanks to [@rogercampos](http://github.com/rogercampos) for providing the awesome **png_quantizator** gem, which you can find [here](https://github.com/rogercampos/png_quantizator).
 
+Mozjpeg
+-------
+This fork adds simple detection and usage of mozjpeg for JPG compression. If the mozjpeg command is available that one will be used instead of jpegoptim.
+
+How to setup mozjpeg on Ubuntu:
+```
+sudo apt-get install autoconf automake libtool nasm make pkg-config
+git clone https://github.com/mozilla/mozjpeg.git && cd mozjpeg
+autoreconf -fiv
+./configure
+make deb
+sudo dpkg -i mozjpeg_*.deb
+sudo ln -s /opt/mozjpeg/bin/cjpeg /usr/bin/mozjpeg
+```
+
+
 TODO
 ----
 

--- a/lib/piet.rb
+++ b/lib/piet.rb
@@ -34,9 +34,27 @@ module Piet
     end
 
     def optimize_jpg(path, opts)
+      path.gsub!(/([\(\)\[\]\{\}\*\?\\])/, '\\\\\1')
+      if mozjpeg_available?
+        mozjpeg(path, opts)
+      else
+        jpegoptim(path, opts)
+      end
+    end
+
+    def mozjpeg_available?
+      !`which mozjpeg`.empty?
+    end
+
+    def mozjpeg(path, opts)
+      tmp_path = path.split('.').insert(-2, 'original').join('.')
+      `mv #{path} #{tmp_path}`
+      `mozjpeg -outfile #{path} #{tmp_path}`
+    end
+
+    def jpegoptim(path, opts)
       quality = (0..100).include?(opts[:quality]) ? opts[:quality] : 100
       vo = opts[:verbose] ? "-v" : "-q"
-      path.gsub!(/([\(\)\[\]\{\}\*\?\\])/, '\\\\\1')
       `#{command_path("jpegoptim")} -f -m#{quality} --strip-all #{opts[:command_options]} #{vo} #{path}`
     end
 


### PR DESCRIPTION
I wrote "quick and dirty" support for compression with mozjpeg. It checks if a `mozjpeg` command is available, if not it falls back on jpegoptim. You need to compile the binaries yourself, they are not provided by the piet-binary gem.

Maybe it's an idea to introduce a configuration file which can be used to specify the used optimizers, it's binary paths and specific optimizer flags. Don't know if you want to go that way with this project?