### PR TITLE
Add `−strip all` when executing optipng

### DIFF
--- a/lib/piet.rb
+++ b/lib/piet.rb
@@ -30,7 +30,7 @@ module Piet
       level = (0..7).include?(opts[:level]) ? opts[:level] : 7
       vo = opts[:verbose] ? "-v" : "-quiet"
       path.gsub!(/([\(\)\[\]\{\}\*\?\\])/, '\\\\\1')
-      `#{command_path("optipng")} -o#{level} #{opts[:command_options]} #{vo} #{path}`
+      `#{command_path("optipng")} -o#{level} −strip all #{opts[:command_options]} #{vo} #{path}`
     end
 
     def optimize_jpg(path, opts)


### PR DESCRIPTION
Since we have `--strip-all` on `jpegoptim`
Should be fine to put `−strip all` on `optipng`

Might work better than raising optimization level from 2
http://sweetme.at/2013/09/11/how-to-maximize-png-image-compression-with-optipng/