### PR TITLE
fix(optipng): Fix a typo

### DIFF
--- a/lib/piet.rb
+++ b/lib/piet.rb
@@ -30,7 +30,7 @@ module Piet
       level = (0..7).include?(opts[:level]) ? opts[:level] : 7
       vo = opts[:verbose] ? "-v" : "-quiet"
       path.gsub!(/([\(\)\[\]\{\}\*\?\\])/, '\\\\\1')
-      `#{command_path("optipng")} -o#{level} −strip all #{opts[:command_options]} #{vo} #{path}`
+      `#{command_path("optipng")} -o#{level} -strip all #{opts[:command_options]} #{vo} #{path}`
     end
 
     def optimize_jpg(path, opts)


### PR DESCRIPTION
Replace en dash with hyphen. (− => -)

It should be a typo:
```
$ optipng -o7 −strip all lena.png 
** Processing: −strip                                                       
Error: Can't open the input file                                             
                                                                              
** Processing: all                                  
Error: Can't open the input file                                               
                                                                                                                                                       
** Processing: lena.png                                                                                                                            
512x512 pixels, 3x8 bits/pixel, RGB                                 
...
```